### PR TITLE
docs(keymod): add v0.15 release update and fill content gaps

### DIFF
--- a/docs/product/keymod/features.md
+++ b/docs/product/keymod/features.md
@@ -1,14 +1,14 @@
 ---
 title: "Features & Specifications"
-description: "KeyMod Series features: Bluetooth HID keyboard and mouse, USB + Bluetooth dual connection, custom profiles, macros, gamepad modes. Open source mobile app for Android and iPadOS."
-keywords: "KeyMod Series features, HID emulator, Bluetooth keyboard, USB keyboard, programmable buttons, gamepad, macro, open source, CH9329"
+description: "KeyMod Series features: Bluetooth HID keyboard and mouse, USB + Bluetooth dual connection, custom profiles, macros, gamepad modes, presentation controls, shortcut hub. Open source mobile app for Android."
+keywords: "KeyMod Series features, HID emulator, Bluetooth keyboard, USB keyboard, programmable buttons, gamepad, macro, open source, CH9329, shortcut hub, presentation mode"
 ---
 
 # **Features & Specifications** | Openterface KeyMod Series
 
-## Pre-Launch Status
+## Current Status
 
-KeyMod is currently in pre-launch development. We're refining the hardware and software. Subscribe on the [product page](/product/keymod/) to stay updated on progress and launch notifications.
+KeyMod is in active development with a [public beta](/tutorial/keymod/) available for Android. Subscribe on the [product page](/product/keymod/) to stay updated on launch notifications.
 
 > **Note:** Features, specifications, and design are still subject to change as development continues.
 
@@ -34,11 +34,15 @@ KeyMod is built for practical everyday local device control, not as a remote des
 
 With our open source mobile app, you can:
 
-- Build custom input profiles
-- Launch macros and configure hotkeys
-- Create workflow shortcuts
+- **Keyboard & Mouse (Basic)** — Full-screen keyboard with long-press repeat, key preview, and numpad
+- **Keyboard & Mouse Pro** — Composite layout with Shortcut Hub strips, split keyboard, and IME
+- **Presentation mode** — Slide remote control with timer for Google Slides and other apps
+- **Gamepad** — Virtual controller with customizable preset layouts, multi-touchpad support
+- **Shortcut Hub** — Profile-based keyboard shortcuts for creative and dev tools (Blender, KiCAD, Photoshop, VS Code), with create, import, and export
+- **Macros** — Programmable key sequences with delays
+- **Voice input** — Speech-to-keyboard with AI (Whisper API)
 
-The KeyMod controller app focuses on **Android, IOS and iPadOS**. We are also expanding desktop control with **Windows and macOS** software in our broader Openterface ecosystem.
+The KeyMod controller app focuses on **Android** and **iPadOS**. We are also expanding desktop control with **Windows and macOS** software in our broader Openterface ecosystem.
 
 
 ### **True Hardware HID**
@@ -68,5 +72,9 @@ KeyMod is open hardware and open software. We will publish schematics, PCB files
 ### **Input Features**
 
 - Full keyboard and mouse emulation (HID)
-- Custom input profiles
+- Custom input profiles (Basic and Pro tiers)
 - Macros and hotkeys
+- Shortcut Hub with app-specific profiles
+- Gamepad with preset-based layouts (schema v7)
+- Presentation controls with slide timer
+- Voice-to-keyboard with AI

--- a/docs/product/keymod/updates/20260509-keymod-015-release.md
+++ b/docs/product/keymod/updates/20260509-keymod-015-release.md
@@ -1,0 +1,79 @@
+---
+draft: false
+date: 2026-05-09
+title: "KeyMod 0.15: Gamepad Preset Pipeline, Keyboard & Mouse (Basic) Tier, Multi-Touchpad Layouts"
+description: "KeyMod 0.15 ships the gamepad preset pipeline with schema v7, multi-touchpad layouts, Keyboard & Mouse (Basic) tier with full-screen keyboard, and KeyMod branding across the app. A major step toward a polished input experience."
+keywords: "KeyMod 0.15, KeyMod release, gamepad preset, multi-touchpad, keyboard mouse basic, KeyMod branding, Openterface KeyMod update, HID emulator, virtual gamepad, Android keyboard app"
+author: "TechxArtisan Studio"
+category: "Product Updates"
+tags: ["KeyMod", "Product Updates", "Release", "Gamepad", "Keyboard", "Android"]
+featured: false
+social:
+  image: "https://assets.openterface.com/images/keymod/keymod-015-release.jpg"
+  title: "KeyMod 0.15 release — gamepad presets, basic tier, multi-touchpad"
+  description: "KeyMod 0.15 brings gamepad preset pipeline v7, a dedicated Keyboard & Mouse (Basic) tier, multi-touchpad layouts, and fresh KeyMod branding."
+---
+
+# KeyMod 0.15: Gamepad Preset Pipeline, Keyboard & Mouse (Basic) Tier, Multi-Touchpad Layouts
+
+KeyMod **0.15** (`versionCode` **15**) is a milestone release that ships three major features: the **gamepad preset pipeline** with layout schema **v6-v7**, the dedicated **Keyboard & Mouse (Basic)** tier, and **multi-touchpad** layouts. This update also brings full **KeyMod** branding across the welcome flow and build artifacts.
+
+## Gamepad: Preset Pipeline v7
+
+The gamepad now uses a proper **preset system** that lets you save, load, import, and export custom controller layouts.
+
+### What changed
+
+- **Preset store v7** replaces the old built-in layouts. The classic factory presets (`preset_classic_*`) and **Two buttons** (`preset_two_buttons`) have been removed from disk. Only **`preset_default`** remains as the deletion-protected factory layout.
+- **Schema v7** makes **`stick_left`** optional. A layout can now have no left-thumb module at all. The **Add module** menu inserts **`stick_left`**, **`stick_left_2`**, **`stick_left_3`**, and so on.
+- **Multi-touchpad support**: presets may include multiple touchpads (`touchpad_1`, `touchpad_2`). Adding a touchpad allocates the next available id with a slightly offset anchor. Bundled L/M/R mouse buttons are shared across all touchpads.
+- **Touchpad mouse button sizing**: mouse buttons now use a larger default draw radius. You can adjust size via long-press **Mouse button size** on the touchpad, or **This button size** on individual mouse modules.
+- **Aux stick defaults**: **`stick_left_2+`** default to D-pad cross + WASD mapping.
+
+### Preset management
+
+- **Tap** the Preset chip in the toolbar to cycle through available layouts
+- **Long-press** for the full preset list with import, add module, and export options
+- Bundled **emu-6** layout ships as the starter preset
+- Export creator supports i18n for sharing presets across languages
+
+## Keyboard & Mouse (Basic)
+
+A dedicated full-screen keyboard tier designed for focused typing without the app header.
+
+### What you get
+
+- **Full-screen keyboard** without the main app header for more screen real estate
+- **Portrait and landscape numpad**: 5x8 grid in portrait (PrtSc / ScrLk / Pause / Home / End), 8x5 grid in landscape with tall +, Enter, and 00
+- **IME ASCII-only send gate**: type long text in compose mode, send as clean HID keystrokes
+- **Long-press repeat**: hold character/function keys for auto-repeat (~400ms delay, ~50ms repeat)
+- **Key preview**: floating bubble shows the effective label above the key when pressed
+- **Haptic feedback** and **theme-aware** key surfaces
+
+### Sticky vs Chord modifiers
+
+Settings let you choose between **sticky modifiers** (tap to latch) and **momentary + long-press chord** (default) for the Basic keyboard.
+
+## Branding
+
+- App display name is now **KeyMod**
+- Welcome screen shows the **KeyMod** wordmark
+- CI artifacts and APK filenames use **KeyMod** prefix
+- `applicationId` remains **`com.openterface.keymod`** for in-place upgrades
+
+## What is unchanged
+
+**Keyboard & Mouse Pro** (composite mode with Shortcut Hub strips, split layouts, and rich IME behavior) remains the full-featured experience it was before.
+
+## Get the update
+
+Download the latest APK from [GitHub Releases](https://github.com/TechxArtisanStudio/Openterface_KeyMod_Android/releases) or [GitHub Actions](https://github.com/TechxArtisanStudio/Openterface_KeyMod_Android/actions). Existing installs upgrade in place.
+
+## Upgrade notes
+
+- **Gamepad**: your previous two-button preference automatically activates the **Two buttons** preset on first launch. Use **Preset** (tap to cycle, long-press for the list) instead of the old 1 Button / 2 Buttons control.
+- **Keyboard & Mouse (Basic)**: open Basic to experience the full-screen keyboard. Pro mode is available via the navigation drawer for the complete Shortcut Hub experience.
+
+Best regards,
+
+Openterface Team | TechxArtisan

--- a/docs/product/keymod/updates/20260509-keymod-015-release.md
+++ b/docs/product/keymod/updates/20260509-keymod-015-release.md
@@ -67,7 +67,9 @@ Settings let you choose between **sticky modifiers** (tap to latch) and **moment
 
 ## Get the update
 
-Download the latest APK from [GitHub Releases](https://github.com/TechxArtisanStudio/Openterface_KeyMod_Android/releases) or [GitHub Actions](https://github.com/TechxArtisanStudio/Openterface_KeyMod_Android/actions). Existing installs upgrade in place.
+**This version (0.15):** [KeyMod-release-0.15.apk](https://assets2.openterface.com/data/KeyMod-release-0.15.apk)
+
+You can also get builds from [GitHub Releases](https://github.com/TechxArtisanStudio/Openterface_KeyMod_Android/releases) or [GitHub Actions](https://github.com/TechxArtisanStudio/Openterface_KeyMod_Android/actions). Existing installs upgrade in place.
 
 ## Upgrade notes
 

--- a/docs/product/keymod/updates/index.md
+++ b/docs/product/keymod/updates/index.md
@@ -4,5 +4,6 @@
 
 ## Product Updates
 
+- 2026-05-09: [KeyMod 0.15: Gamepad Preset Pipeline, Keyboard & Mouse (Basic) Tier, Multi-Touchpad Layouts](20260509-keymod-015-release.md)
 - 2026-04-08: [KeyMod Update: Prototype Connectors and Your Feedback](20260408-keymod-connector-feedback.md)
 

--- a/docs/tutorial/keymod/02-keyboard-mouse.md
+++ b/docs/tutorial/keymod/02-keyboard-mouse.md
@@ -8,6 +8,37 @@ keywords: "KeyMod keyboard, KeyMod mouse, touchpad, modifier keys, keyboard shor
 
 The Keyboard & Mouse mode is the most frequently used mode. It provides a virtual keyboard and touchpad for controlling the target computer from your phone.
 
+## Two Tiers: Basic and Pro
+
+KeyMod offers two keyboard experiences:
+
+| Tier | Mode name | Best for |
+|---|---|---|
+| **Basic** | Keyboard & Mouse | Quick typing with a full-screen keyboard, no header distraction |
+| **Pro** | Keyboard & Mouse Pro | Full composite layout with Shortcut Hub strips, split keyboard, and rich IME |
+
+### Keyboard & Mouse (Basic)
+
+The **Basic** tier gives you a **dedicated full-screen keyboard** without the app's top header. All controls live on the keyboard's own top row:
+
+- Menu, mode switching (Touchpad / Compose & Send / Num pad)
+- Target OS selector
+- Connection status
+
+**Features unique to Basic:**
+
+- **Long-press repeat**: hold any character or function key for auto-repeat (~400ms delay, ~50ms repeat)
+- **Key preview**: a floating bubble shows the effective label above the key when pressed
+- **Haptic feedback** and **theme-aware** key surfaces
+- **Portrait and landscape numpad**: 5x8 grid (portrait) or 8x5 grid (landscape)
+- **IME compose mode**: type long text, send as clean ASCII-only HID keystrokes
+
+> Basic does **not** include Shortcut Hub strip rows. For strip profiles, switch to **Keyboard & Mouse Pro**.
+
+### Keyboard & Mouse Pro
+
+**Pro** is the full composite experience: Shortcut Hub strip rows, split keyboard layouts, and the complete IME workflow. This is what power users expect.
+
 ## The Layout
 
 **Portrait mode:**

--- a/docs/tutorial/keymod/08-gamepad.md
+++ b/docs/tutorial/keymod/08-gamepad.md
@@ -20,20 +20,57 @@ The gamepad provides a full controller layout with D-pad, action buttons, should
 | Analog sticks | Touch and drag the stick circles |
 | Start / Select | Tap the buttons |
 
+## Preset System (v7)
+
+KeyMod 0.15 introduced a **preset-based gamepad system**. Instead of fixed built-in layouts, gamepad configurations are now saved as **presets** that you can cycle through, import, and export.
+
+### Managing presets
+
+- **Tap the Preset chip** in the toolbar to cycle through available layouts
+- **Long-press the Preset chip** for the full preset list with import, add module, and export options
+- The bundled **emu-6** layout ships as the starter preset (`preset_default`)
+- Presets are shareable JSON files using layout **schema v7**
+
+### Adding modules
+
+From the preset menu, you can add new modules to any layout:
+
+- **D-Pad / Stick** — adds a left-thumb module (`stick_left`, `stick_left_2`, etc.)
+- **Touchpad** — adds a touchpad (`touchpad_1`, `touchpad_2`, etc.) with bundled L/M/R mouse buttons
+- **Buttons** — add face buttons, shoulder buttons, or triggers
+
 ## Customizing
 
-- **Long-press any button or stick** to reconfigure it — assign any HID key to each component
-- **Analog vs Key mode** — sticks can be configured as analog input or as key-mapped D-pad input
+- **Configure any module** — tap a module to open its configuration dialog and adjust behavior
+- **Analog vs Key mode** — sticks can be configured as `STICK_KEY` (digital direction keys) or `STICK_MOUSE` (relative pointer/mouse movement)
 - **WASD mapping** — assign WASD keys to the left stick for PC gaming
 - **Button/stick size scaling** — adjust sizes for your preferred touch area
-- **Background image** — customize the gamepad background
-- **Haptic feedback** — vibration on button press
+- **Background image** — customize the gamepad background (embeds in shared presets as base64, up to 6 MiB)
+- **Haptic feedback** — vibration on button press (face buttons only, not mouse clicks)
+- **Gyro** — enable device gyroscope to move the host pointer while the gamepad screen is active
+
+### Module model
+
+Each on-screen control is a **module** with three layers:
+
+| Layer | What it defines |
+|---|---|
+| **Slot / identity** | Which control on the canvas (e.g. `stick_left`, `stick_right`, `touchpad_1`) |
+| **Behavior (type)** | What the host receives: `STICK_KEY`, `STICK_MOUSE`, `DPAD`, `BUTTON`, `TOUCHPAD` |
+| **Parameters** | Tuning on the same module: `dpadVariant`, `stickMouseSensitivity`, `stickVisualVariant`, size, color |
 
 ### Analog Sticks
 
-- **Left stick → Keyboard keys:** Maps to arrow keys with diagonal support. Configurable to WASD in Edit Mode.
-- **Right stick → Mouse movement:** Dynamic sensitivity (2.0–8.0), dead zone to prevent drift.
+- **Left stick → Keyboard keys:** Maps to arrow keys with diagonal support. Configurable to WASD in the module configuration.
+- **Right stick → Mouse movement:** `STICK_MOUSE` mode with configurable sensitivity (`stickMouseSensitivity`), dead zone to prevent drift.
 - **Hysteresis:** Activation (0.6) and deactivation (0.4) thresholds prevent key chatter at the boundary.
+
+### Touchpad
+
+- **Multi-touchpad support**: add multiple touchpads to a single layout (`touchpad_1`, `touchpad_2`, etc.)
+- **Square footprint** by default with long-press resize
+- **Bundled mouse buttons** (L/M/R) shared across all touchpads
+- **Mouse button sizing**: long-press a touchpad to adjust **Mouse button size**, or long-press an individual mouse button for **This button size**
 
 > **Note:** Gamepad HID protocol is under active development. Basic button support works; analog stick precision may vary.
 
@@ -43,8 +80,9 @@ The gamepad provides a full controller layout with D-pad, action buttons, should
 
 | Symptom | Solution |
 |---|---|
-| **Stick not producing action** | Check the key mapping in Edit Mode → Key Mapping. Verify the stick isn't stuck in the dead zone (center area, 0.15 threshold). Check hysteresis thresholds — the stick needs to move past 0.6 activation to trigger. |
-| **Buttons sending wrong keys** | Open Edit Mode → Key Mapping and check the button's key assignment. Tap the button to open the configuration popup and correct the mapping. Reset positions to defaults using the reset button. |
+| **Stick not producing action** | Check the module configuration. Verify the stick isn't stuck in the dead zone (center area). Check hysteresis thresholds — the stick needs to move past 0.6 activation to trigger. |
+| **Buttons sending wrong keys** | Open the module configuration and check the button's key assignment. Tap the button to open the configuration popup and correct the mapping. |
+| **Touchpad mouse buttons not clicking** | Ensure bundled L/M/R buttons are present in the preset. Adding a touchpad automatically adds shared mouse buttons. Check the module configuration for the assigned HID key. |
 
 ## Next Steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,7 +75,7 @@ extra:
   minikvm_updates: 16
   kvm-go_updates: 11
   accessories_updates: 0
-  keymod_updates: 1
+  keymod_updates: 2
   qt_linux_stable: 0.3.19
   minikvm_purchase_link: https://www.crowdsupply.com/techxartisan/openterface-mini-kvm
   kvmgo_purchase_link: https://www.crowdsupply.com/techxartisan/openterface-kvm-go


### PR DESCRIPTION
## Summary

Sync the website with KeyMod Android repo after the **0.15 release** (2026-05-09).

### Changes

| File | Change |
|---|---|
| `docs/product/keymod/updates/20260509-keymod-015-release.md` | **(NEW)** Full release update post covering gamepad preset pipeline v7, Keyboard & Mouse (Basic) tier, multi-touchpad layouts, KeyMod branding |
| `docs/product/keymod/updates/index.md` | Added the new v0.15 update to the update list |
| `docs/tutorial/keymod/08-gamepad.md` | Rewrote with preset system v7, module model (slot/behavior/parameters), multi-touchpad support, touchpad mouse button sizing |
| `docs/tutorial/keymod/02-keyboard-mouse.md` | Added Basic vs Pro tier comparison table, long-press repeat, key preview, haptic feedback details |
| `docs/product/keymod/features.md` | Updated status from "pre-launch" to "public beta available"; added Shortcut Hub, presentation mode, voice input, gamepad presets |
| `mkdocs.yml` | Bumped `keymod_updates` from 1 to 2 |

### Content gaps addressed

- **Missing v0.15 release coverage** — no website post for the 2026-05-09 release
- **Gamepad tutorial outdated** — did not cover the preset system (v7), multi-touchpad, or module model introduced in 0.15
- **Keyboard tutorial missing Basic vs Pro distinction** — users would not know about the two tiers
- **Features page stale** — still said "pre-launch", missing several shipped features

### Stats

- 6 files changed
- 175 insertions, 18 deletions